### PR TITLE
Fix welcome new user - Fixes bug #95

### DIFF
--- a/lib/onEvent/guildMemberAdd.js
+++ b/lib/onEvent/guildMemberAdd.js
@@ -56,8 +56,8 @@ Kirbi.Discord.on('guildMemberAdd', member => {
 	guildSettings.recentMembers.push(member);
 	
 
-	if(!guildSettings.kicking && member.guild.id === Kirbi.Config.welcomeGuild) {
-		member.send(`Welcome, ${member.user.username}, to the GReY Community!\nBe sure to read our <#${Kirbi.Config.welcomeChannel}> channel for an overview of our rules and features.`);
+	if(!guildSettings.kicking) {
+		member.send(`Welcome, ${member.user.username}, to the ${member.guild.name} server!\nBe sure to read our <#${Kirbi.Config.discord.welcomeChannel}> channel for an overview of our rules and features.`);
 		if (channel) channel.send(`@here, please Welcome ${member.user.username} to ${member.guild.name}!`);	
 	}
 });


### PR DESCRIPTION
Resolves bug Richardson-Media-House/Kirbi#95

Originally written to only be in one channel, I've removed the welcome guild requirement so the welcome will be in every guild whenever there is a join. Also changed the name of the server being joined. We will need to update the channel for rules, but that will be another ticket.